### PR TITLE
Added Provider for Tiktok

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Matinee::make('video')
 
 ## Custom Providers
 
-Matinee comes with a Provider for YouTube and Vimeo, but you can add your own by creating a class and passing it into the `providers` modifier on the field.
+Matinee comes with a Provider for YouTube, Vimeo and Tiktok, but you can add your own by creating a class and passing it into the `providers` modifier on the field.
 
 ```php
 use Awcodes\Matinee\Providers\Concerns\IsMatineeProvider;

--- a/src/Matinee.php
+++ b/src/Matinee.php
@@ -3,6 +3,7 @@
 namespace Awcodes\Matinee;
 
 use Awcodes\Matinee\Providers\Contracts\MatineeProvider;
+use Awcodes\Matinee\Providers\TiktokProvider;
 use Awcodes\Matinee\Providers\VimeoProvider;
 use Awcodes\Matinee\Providers\YoutubeProvider;
 use Closure;
@@ -156,7 +157,7 @@ class Matinee extends FormsComponent
     {
         return collect([
             ...$this->providers ?? [],
-            ...[VimeoProvider::class, YoutubeProvider::class],
+            ...[VimeoProvider::class, YoutubeProvider::class, TiktokProvider::class],
         ])->mapWithKeys(function ($provider) {
             $instance = $provider::make();
             $domains = $instance->getDomains();

--- a/src/Providers/TiktokProvider.php
+++ b/src/Providers/TiktokProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Awcodes\Matinee\Providers;
+
+use Awcodes\Matinee\Providers\Concerns\IsMatineeProvider;
+use Illuminate\Support\Str;
+
+class TiktokProvider implements Contracts\MatineeProvider
+{
+    use IsMatineeProvider;
+
+    public function getDomains(): array
+    {
+        return [
+            'tiktok.com',
+        ];
+    }
+
+    public function getOptions(): array
+    {
+        return [
+            'controls' => 1,
+            'loop' => 0,
+            'progress_bar' => 1,
+            'volume_control' => 1,
+            'fullscreen_button' => 1,
+        ];
+    }
+
+    public function convertUrl(?array $options = []): string
+    {
+        $baseUrl = 'https://www.tiktok.com/player/v1/';
+
+        if (Str::of($this->url)->contains('/video/')) {
+            preg_match('/([0-9]+)/', $this->url, $matches);
+            $id = $matches[1] ?? null;
+        } else {
+            preg_match('/\.com\/([0-9]+)/', $this->url, $matches);
+            $id = $matches[1] ?? null;
+        }
+
+        $baseUrl = $baseUrl . $id;
+
+        if (filled($options)) {
+            $query = http_build_query($options);
+
+            return "{$baseUrl}?{$query}";
+        }
+
+        return $baseUrl;
+    }
+}

--- a/src/Providers/YoutubeProvider.php
+++ b/src/Providers/YoutubeProvider.php
@@ -42,8 +42,11 @@ class YoutubeProvider implements Contracts\MatineeProvider
 
         if (Str::of($this->url)->contains('youtu.be')) {
             $id = Str::of($this->url)->after('youtu.be/');
-        } else {
+        } elseif (Str::of($this->url)->contains('/v=')){
             preg_match('/v=([-\w]+)/', $this->url, $matches);
+            $id = $matches[1] ?? null;
+        } else {
+            preg_match('/shorts\/([-\w]+)/', $this->url, $matches);
             $id = $matches[1] ?? null;
         }
 

--- a/src/Providers/YoutubeProvider.php
+++ b/src/Providers/YoutubeProvider.php
@@ -42,7 +42,7 @@ class YoutubeProvider implements Contracts\MatineeProvider
 
         if (Str::of($this->url)->contains('youtu.be')) {
             $id = Str::of($this->url)->after('youtu.be/');
-        } else{
+        } else {
             preg_match('/v=([-\w]+)/', $this->url, $matches);
             $id = $matches[1] ?? null;
         }

--- a/src/Providers/YoutubeProvider.php
+++ b/src/Providers/YoutubeProvider.php
@@ -42,11 +42,8 @@ class YoutubeProvider implements Contracts\MatineeProvider
 
         if (Str::of($this->url)->contains('youtu.be')) {
             $id = Str::of($this->url)->after('youtu.be/');
-        } elseif (Str::of($this->url)->contains('/v=')){
+        } else{
             preg_match('/v=([-\w]+)/', $this->url, $matches);
-            $id = $matches[1] ?? null;
-        } else {
-            preg_match('/shorts\/([-\w]+)/', $this->url, $matches);
             $id = $matches[1] ?? null;
         }
 


### PR DESCRIPTION
This pull request adds support for embedding TikTok videos to the package, which previously supported YouTube and Vimeo. The changes include:

1. New TiktokProvider: Created a `TiktokProvider` class that implements the `MatineeProvider` contract, adding methods to handle TikTok URLs, options, and conversions.

2. Update Matinee Providers: Added `TiktokProvider::class` to the `getProviders()` method in `Matinee.php` to integrate TikTok as a supported provider.

3. Documentation Update: Updated the `README.md` file to reflect the addition of TikTok as a supported video provider, including instructions for usage and customization.

These enhancements allow users to seamlessly embed TikTok videos alongside YouTube and Vimeo, expanding the versatility of the package.