### PR TITLE
Add Support for YouTube Shorts in URL Conversion Method

### DIFF
--- a/src/Providers/YoutubeProvider.php
+++ b/src/Providers/YoutubeProvider.php
@@ -42,6 +42,8 @@ class YoutubeProvider implements Contracts\MatineeProvider
 
         if (Str::of($this->url)->contains('youtu.be')) {
             $id = Str::of($this->url)->after('youtu.be/');
+        } elseif (Str::of($this->url)->contains('youtube.com/shorts/')) {
+            $id = Str::of($this->url)->after('youtube.com/shorts/');
         } else {
             preg_match('/v=([-\w]+)/', $this->url, $matches);
             $id = $matches[1] ?? null;


### PR DESCRIPTION
This adds the support for YouTube Shorts URLs to the `convertUrl` method. Previously, the method only supported standard YouTube video URLs and youtu.be links. With this update, the method now correctly identifies and converts YouTube Shorts URLs into embeddable URLs.

A YouTube Shorts URL like https://www.youtube.com/shorts/{id} will now be correctly converted to an embeddable URL.

Changes:

Added a condition to check for YouTube Shorts URLs containing youtube.com/shorts/ and extract the video ID.

Before this change:
![image](https://github.com/user-attachments/assets/fd7b0b83-8329-4625-8987-1c71bc4cdc74)

After this change:
![image](https://github.com/user-attachments/assets/029b523a-6bbc-4524-abd2-854e2bfbf565)
