### PR TITLE
Add Spanish translations

### DIFF
--- a/resources/lang/es/matinee.php
+++ b/resources/lang/es/matinee.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'url' => 'URL',
+    'width' => 'Ancho',
+    'height' => 'Alto',
+    'responsive' => 'Responsivo',
+    'responsive_helper' => 'Si el video no es responsivo, establece el ancho y alto en los píxeles reales que debe tener el video. El valor por defecto es 640x480.',
+    'autoplay' => 'Reproducción automática',
+    'loop' => 'Repetir',
+    'title' => 'Título',
+    'byline' => 'Autor',
+    'portrait' => 'Retrato',
+    'controls' => 'Controles',
+    'nocookie' => 'Sin cookies',
+    'start_at' => 'Iniciar en',
+    'local' => 'Local',
+    'preview' => 'Vista previa',
+    'show_preview' => 'Mostrar vista previa',
+    'hide_preview' => 'Ocultar vista previa',
+    'options' => 'Opciones',
+    'invalid_url' => 'No existe un proveedor compatible para esta URL.',
+];


### PR DESCRIPTION
Adds spanish translations for all Matinee UI strings.

Tested locally with APP_LOCALE=es in a Filament v3 project.